### PR TITLE
🚚 Rename composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "sitnikovik/console",
-    "description": "Beatifies your cli scripts with colors, bolds, loading bars and much more",
+    "name": "sitnikovik/clipher",
+    "description": "CLI tool to beatify your scripts with colors, bolds, loading bars and much more",
     "type": "library",
     "license": "MIT",
     "autoload": {


### PR DESCRIPTION
I made a decision to rename the package into more satisfying name as clipher.
Guess it have no big matter because it have no composer installs yet. 